### PR TITLE
CI: inherit secrets in coverage workflow.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.4"
       make: "init coverage"


### PR DESCRIPTION
## What changed
- Added `secrets: inherit` to `.github/workflows/coverage.yml` for the reusable coverage workflow caller.

## Why
- The reusable coverage workflow needs inherited secrets to support the issue 74 rollout across repositories.
- Relates to contributte/contributte#74.