### PR TITLE
Replace phpdbg with php in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src app tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src app tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src app tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src app tests/Cases
 endif
 
 .PHONY: dev


### PR DESCRIPTION
## Summary
- What changed: replaced `-p phpdbg` with `-p php` in the `Makefile` coverage target for both local and CI coverage runs.
- Why: aligns this repo with the phpdbg-removal cleanup tracked in contributte/contributte#73.

## Testing
- `make -n coverage`
- `make -n coverage GITHUB_ACTION=1`